### PR TITLE
fix: missing tailoring parameter

### DIFF
--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -11,10 +11,10 @@ interface ListEntry {
 }
 
 export function Home() {
-  const { modelVariantId } = useTailoring();
+  const { tailoringParameter } = useTailoring();
 
   useEffect(() => {
-    if (modelVariantId) {
+    if (tailoringParameter.modelVariantId) {
       async function getModelVariantData() {
         await fetchModelVariantData();
       }
@@ -22,13 +22,13 @@ export function Home() {
       getModelVariantData().then();
     }
     //eslint-disable-next-line
-  }, [modelVariantId]);
+  }, [tailoringParameter.modelVariantId]);
 
   const [modelVariantData, setModelVariantData] = useState<ListEntry[] | undefined>(undefined);
 
   async function fetchModelVariantData(): Promise<void> {
     const projectModelVariantUrl =
-      'https://vm-api.weit-verein.de/V-Modellmetamodell/mm_2021/V-Modellvariante/' + modelVariantId;
+      'https://vm-api.weit-verein.de/V-Modellmetamodell/mm_2021/V-Modellvariante/' + tailoringParameter.modelVariantId;
 
     const jsonDataFromXml: any = await getJsonDataFromXml(projectModelVariantUrl);
 
@@ -51,7 +51,7 @@ export function Home() {
 
   return (
     <>
-      <h1>Home</h1>
+      <h1>Info</h1>
       <Row>
         <Col xs={24} sm={24} md={12}>
           <List
@@ -73,7 +73,7 @@ export function Home() {
           <img
             alt="ALLG-Titelseite-Prozessdoku"
             id="ALLG-Titelseite-Prozessdoku"
-            src={`https://vm-api.weit-verein.de/Tailoring/V-Modellmetamodell/mm_2021/V-Modellvariante/${modelVariantId}/Projekttyp/xxx/Projekttypvariante/xxx/Grafik/images/ALLG-Titelseite-Prozessdoku.png`}
+            src={`https://vm-api.weit-verein.de/Tailoring/V-Modellmetamodell/mm_2021/V-Modellvariante/${tailoringParameter.modelVariantId}/Projekttyp/xxx/Projekttypvariante/xxx/Grafik/images/ALLG-Titelseite-Prozessdoku.png`}
           />
         </Col>
       </Row>

--- a/client/src/components/app/App.tsx
+++ b/client/src/components/app/App.tsx
@@ -18,11 +18,12 @@ function App() {
       <Layout>
         <Content style={{ padding: '0 25px' }}>
           <Routes>
-            <Route path="/" element={<Home />} />
+            <Route path="/" element={<Project />} />
             <Route path="/tailoring" element={<Project />} />
             <Route path="/documentation" element={<Documentation />} />
             <Route path="/documentation/:id" element={<Documentation />} />
             <Route path="/productTemplates" element={<Templates />} />
+            <Route path="/info" element={<Home />} />
             {/*<Route path="*" element={<HomeComponent />} />*/}
           </Routes>
         </Content>

--- a/client/src/components/header/SiteHeader.tsx
+++ b/client/src/components/header/SiteHeader.tsx
@@ -10,16 +10,6 @@ const { Header } = Layout;
 
 const items: MenuProps['items'] = [
   {
-    label: (
-      <LinkWithQuery to="/">Home</LinkWithQuery>
-      // <LinkWithQuery href="#/" children={undefined} to={undefined}>
-      //   Home
-      // </LinkWithQuery>
-    ),
-    key: 'home',
-    icon: <HomeOutlined />,
-  },
-  {
     label: <LinkWithQuery to="/tailoring">Tailoring</LinkWithQuery>,
     // <a href="#/tailoring">Tailoring</a>,
     key: 'tailoring',
@@ -36,6 +26,16 @@ const items: MenuProps['items'] = [
     // label: <a href="#/productTemplates">Produktvorlagen</a>,
     key: 'productTemplates',
     icon: <BookOutlined />,
+  },
+  {
+    label: (
+      <LinkWithQuery to="/info">Info</LinkWithQuery>
+      // <LinkWithQuery href="#/" children={undefined} to={undefined}>
+      //   Home
+      // </LinkWithQuery>
+    ),
+    key: 'info',
+    icon: <HomeOutlined />,
   },
 ];
 
@@ -57,7 +57,7 @@ const items: MenuProps['items'] = [
 // </Menu.Item>
 
 export const SiteHeader = (props: any) => {
-  const { modelVariantId } = useTailoring();
+  const { tailoringParameter } = useTailoring();
 
   // const navigate = useNavigate();
 
@@ -67,7 +67,7 @@ export const SiteHeader = (props: any) => {
   // }
   // };
 
-  const { error, image } = useImage(modelVariantId + '/ALLG-Logo-Farbe.gif');
+  const { error, image } = useImage(tailoringParameter.modelVariantId + '/ALLG-Logo-Farbe.gif');
 
   // TODO
   // if (error) {

--- a/client/src/components/projekthandbuch/documentation/content/content.tsx
+++ b/client/src/components/projekthandbuch/documentation/content/content.tsx
@@ -450,7 +450,7 @@ export function Content() {
           productDataArray.push(
             <div key={menuEntryChildren?.id} style={{ marginTop: '40px' }}>
               <h3 id={menuEntryChildren?.id}> {menuEntryChildren.header} </h3>
-              {parse(subPageEntries.descriptionText)}
+              {parse(fixLinksInText(subPageEntries.descriptionText))}
               <DataTable data={subPageEntries?.tableEntries} />
             </div>
           );
@@ -540,7 +540,7 @@ export function Content() {
     return {
       id: jsonDataFromXml.attributes.id,
       header: jsonDataFromXml.attributes.name,
-      descriptionText: fixLinksInText(replaceUrlInText(textPart)),
+      descriptionText: replaceUrlInText(textPart),
       tableEntries: tableEntries,
     };
   }
@@ -747,7 +747,7 @@ export function Content() {
       productDataArray.push(
         <div key={selectedPageEntry?.id}>
           <h2 id={selectedPageEntry?.id}> {selectedPageEntry?.header} </h2>
-          {parse(selectedPageEntry?.descriptionText)}
+          {parse(fixLinksInText(selectedPageEntry?.descriptionText))}
           <DataTable data={selectedPageEntry?.tableEntries} />
 
           {selectedPageEntry && selectedPageEntry?.dataSource && (
@@ -792,11 +792,11 @@ export function Content() {
   }
 
   function fixLinksInText(testString: string): string {
-    // setPathSnippets(location.pathname.split('/').filter((i) => i));
-    const url = '#/documentation/'; // TODO
+    const url = '#/documentation/';
 
+    // TODO: only replace link to entries if they match a navigation id otherwise it is a local reference to an anchor
+    //  on the same page like in glossary
     return testString.replace(/href=['"]#(?:[^"'\/]*\/)*([^'"]+)['"]/g, 'href="' + url + '$1' + location.search + '"');
-    // return testString.replace(
   }
 
   async function fetchSectionDetailsData(sectionId: string): Promise<any> {
@@ -813,7 +813,7 @@ export function Content() {
       id: jsonDataFromXml.attributes.id,
       header: jsonDataFromXml.attributes.titel,
       generatedContent: jsonDataFromXml.attributes.GenerierterInhalt,
-      descriptionText: fixLinksInText(replaceUrlInText(textPart)),
+      descriptionText: replaceUrlInText(textPart),
       tableEntries: [],
       subPageEntries: [],
     };
@@ -1160,7 +1160,7 @@ export function Content() {
     return {
       id: jsonDataFromXml.attributes.id,
       header: jsonDataFromXml.attributes.name,
-      descriptionText: fixLinksInText(sinnUndZweck),
+      descriptionText: sinnUndZweck,
       tableEntries: tableEntries,
       subPageEntries: subPageEntries,
     };
@@ -2367,7 +2367,7 @@ export function Content() {
         title: 'Erläuterung',
         dataIndex: 'explanation',
         key: 'explanation',
-        render: (html: string) => <span dangerouslySetInnerHTML={{ __html: html }} />,
+        render: (html: string) => <span dangerouslySetInnerHTML={{ __html: fixLinksInText(html) }} />,
       },
     ];
 
@@ -2437,7 +2437,7 @@ export function Content() {
         title: 'Begriff',
         dataIndex: 'expression',
         key: 'expression',
-        render: (html: string) => <span dangerouslySetInnerHTML={{ __html: html }} />,
+        render: (html: string) => <span dangerouslySetInnerHTML={{ __html: fixLinksInText(html) }} />,
       },
     ];
 
@@ -2504,7 +2504,7 @@ export function Content() {
         title: 'Erläuterung',
         dataIndex: 'explanation',
         key: 'explanation',
-        render: (html: string) => <span dangerouslySetInnerHTML={{ __html: html }} />,
+        render: (html: string) => <span dangerouslySetInnerHTML={{ __html: fixLinksInText(html) }} />,
       },
     ];
 
@@ -2571,7 +2571,7 @@ export function Content() {
         title: t('translation:label.sourceReference'),
         dataIndex: 'reference',
         key: 'reference',
-        render: (html: string) => <span dangerouslySetInnerHTML={{ __html: html }} />,
+        render: (html: string) => <span dangerouslySetInnerHTML={{ __html: fixLinksInText(html) }} />,
       },
     ];
 

--- a/client/src/components/projekthandbuch/documentation/navigation/navigation.tsx
+++ b/client/src/components/projekthandbuch/documentation/navigation/navigation.tsx
@@ -118,7 +118,7 @@ export function Navigation() {
     navigationData,
     setNavigationData,
     currentSelectedKeys,
-    openKeys,
+    // openKeys,
   } = useDocumentation();
 
   const navigate = useNavigate();
@@ -132,7 +132,7 @@ export function Navigation() {
 
   useEffect(() => {
     async function mount() {
-      if (tailoringParameter.modelVariantId !== null) {
+      if (tailoringParameter.modelVariantId) {
         setLoading(true);
         await fetchData();
         setLoading(false);
@@ -848,7 +848,7 @@ export function Navigation() {
               inlineIndent={12}
               items={navigationData}
               selectedKeys={currentSelectedKeys}
-              openKeys={openKeys} // TODO: funzt noch nicht
+              // openKeys={openKeys} // TODO: funzt noch nicht
             />
           )}
 

--- a/client/src/components/projekthandbuch/produktvorlagen/templates.tsx
+++ b/client/src/components/projekthandbuch/produktvorlagen/templates.tsx
@@ -55,13 +55,7 @@ export function Templates() {
 
   const [menuStructure, setMenuStructure] = React.useState<TemplateProps[]>();
 
-  const {
-    modelVariantId,
-    projectTypeVariantId,
-    projectTypeId,
-    getProjectFeaturesQueryString,
-    // projectFeatures,
-  } = useTailoring();
+  const { tailoringParameter, getProjectFeaturesQueryString } = useTailoring();
 
   useEffect(() => {
     async function mount() {
@@ -71,16 +65,16 @@ export function Templates() {
 
     mount().then();
     //eslint-disable-next-line
-  }, [modelVariantId]);
+  }, [tailoringParameter.modelVariantId]);
 
   async function getReferenceProducts(): Promise<TemplateProps[]> {
     const referenceProductsUrl =
       'https://vm-api.weit-verein.de/Tailoring/V-Modellmetamodell/mm_2021/V-Modellvariante/' +
-      modelVariantId +
+      tailoringParameter.modelVariantId +
       '/Projekttyp/' +
-      projectTypeId +
+      tailoringParameter.projectTypeId +
       '/Projekttypvariante/' +
-      projectTypeVariantId +
+      tailoringParameter.projectTypeVariantId +
       '/Disziplin?' +
       getProjectFeaturesQueryString();
 
@@ -130,11 +124,11 @@ export function Templates() {
   async function getTopics(disciplineId: string, productId: string): Promise<TemplateProps[]> {
     const topicUrl =
       'https://vm-api.weit-verein.de/Tailoring/V-Modellmetamodell/mm_2021/V-Modellvariante/' +
-      modelVariantId +
+      tailoringParameter.modelVariantId +
       '/Projekttyp/' +
-      projectTypeId +
+      tailoringParameter.projectTypeId +
       '/Projekttypvariante/' +
-      projectTypeVariantId +
+      tailoringParameter.projectTypeVariantId +
       '/Disziplin/' +
       disciplineId +
       '/Produkt/' +
@@ -173,11 +167,11 @@ export function Templates() {
   async function getTopicContent(topicId: string, disciplineId: string, productId: string): Promise<string> {
     const topicUrl =
       'https://vm-api.weit-verein.de/Tailoring/V-Modellmetamodell/mm_2021/V-Modellvariante/' +
-      modelVariantId +
+      tailoringParameter.modelVariantId +
       '/Projekttyp/' +
-      projectTypeId +
+      tailoringParameter.projectTypeId +
       '/Projekttypvariante/' +
-      projectTypeVariantId +
+      tailoringParameter.projectTypeVariantId +
       '/Disziplin/' +
       disciplineId +
       '/Produkt/' +


### PR DESCRIPTION
set correct tailoring parameter in home(info) and templates
changed order of top menu to show tailoring tab at first because it has to be filled for all other sites temporarily fixed not closing navigation menu by commenting "openKeys" out fixed "loading spinner not shown" for navigation on direct call fixed more links in content (some more to go)